### PR TITLE
append devLocale default messages

### DIFF
--- a/ProductionModePlugin.js
+++ b/ProductionModePlugin.js
@@ -111,16 +111,10 @@ class ProductionModePlugin {
       if (defaultMessages) {
         originalMessages = attributes.messages;
 
-        if (locale === developmentLocale) {
-          // Overwrite it with the extracted default messages.
-          attributes.messages = jsonKeyValue(locale, defaultMessages);
-        } else {
-          // Populate the missing messages with the default messages.
-          attributes.messages = merge(
-            jsonKeyValue(locale, defaultMessages),
-            attributes.messages || {}
-          );
-        }
+        attributes.messages = merge(
+          jsonKeyValue(locale, defaultMessages),
+          attributes.messages || {}
+        );
 
         // Write messages if:
         // 1: `writeMessages` is true, and


### PR DESCRIPTION
development locale messages where replaced by default messages instead of being supplemented by the latter (which makes sense for “default” - dev mode doesn’t have this problem).

Signed-off-by: Frédéric Miserey <frederic@none.net>